### PR TITLE
Add email protection unit test

### DIFF
--- a/encodeEmailForProtection.js
+++ b/encodeEmailForProtection.js
@@ -3,11 +3,11 @@
  * Run this script with Node.js to encode your email
  */
 
-// The email to encode
+// The email to encode when running this file directly
 const emailToEncode = 'kent@ktvuong.com';
 
 // XOR key used in the decoder (must match the one in emailProtection.js)
-const XOR_KEY = 0x1A;
+export const XOR_KEY = 0x1A;
 
 /**
  * Encodes an email address using a Cloudflare-like encoding approach
@@ -15,7 +15,7 @@ const XOR_KEY = 0x1A;
  * @param {string} email - The email address to encode
  * @returns {string} - The encoded email
  */
-function encodeEmail(email) {
+export function encodeEmail(email) {
 	let result = '';
 
 	// Convert each character to its hex representation after XOR with key
@@ -28,32 +28,30 @@ function encodeEmail(email) {
 	return result;
 }
 
-const encodedEmail = encodeEmail(emailToEncode);
-console.log('Original email:', emailToEncode);
-console.log('Encoded email (use this in data-cfemail attribute):', encodedEmail);
+import { fileURLToPath } from "node:url";
 
-// Test decoding to confirm it works
-function decodeEmail(encoded) {
-	if (encoded.length % 2 !== 0) {
-		throw new Error("Encoded string must have an even length.");
-	}
-
-	if (encoded === "") {
-		return "";
-	}
-
-	const chars = [];
-	for (let i = 0; i < encoded.length; i += 2) {
-		const hexPair = encoded.slice(i, i + 2);
-		const charCode = parseInt(hexPair, 16);
-
-		if (isNaN(charCode)) {
-			throw new Error(`Invalid hex character in input: ${hexPair}`);
-		}
-
-		chars.push(String.fromCharCode(charCode ^ XOR_KEY));
-	}
-	return chars.join("");
+export function decodeEmail(encoded) {
+    if (encoded.length % 2 !== 0) {
+        throw new Error("Encoded string must have an even length.");
+    }
+    if (encoded === "") {
+        return "";
+    }
+    const chars = [];
+    for (let i = 0; i < encoded.length; i += 2) {
+        const hexPair = encoded.slice(i, i + 2);
+        const charCode = parseInt(hexPair, 16);
+        if (isNaN(charCode)) {
+            throw new Error(`Invalid hex character in input: ${hexPair}`);
+        }
+        chars.push(String.fromCharCode(charCode ^ XOR_KEY));
+    }
+    return chars.join("");
 }
 
-console.log('Decoded to verify:', decodeEmail(encodedEmail));
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    const encodedEmail = encodeEmail(emailToEncode);
+    console.log("Original email:", emailToEncode);
+    console.log("Encoded email (use this in data-cfemail attribute):", encodedEmail);
+    console.log("Decoded to verify:", decodeEmail(encodedEmail));
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
-	},
+                "lint": "prettier --check . && eslint .",
+                "test": "node --test"
+        },
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",

--- a/tests/emailProtection.test.js
+++ b/tests/emailProtection.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { encodeEmail } from '../encodeEmailForProtection.js';
+
+function decodeCloudflareEmail(encodedString) {
+  let encoded = encodedString;
+  if (encoded.indexOf('0x') === 0) {
+    encoded = encoded.substr(2);
+  }
+  let r = '';
+  for (let i = 0; i < encoded.length; i += 2) {
+    const hex = encoded.substr(i, 2);
+    const num = parseInt(hex, 16);
+    if (!Number.isNaN(num)) {
+      r += String.fromCharCode(num ^ 0x1a);
+    }
+  }
+  return r;
+}
+
+test('encodeEmail and decodeCloudflareEmail round-trip', () => {
+  const email = 'test@example.com';
+  const encoded = encodeEmail(email);
+  const decoded = decodeCloudflareEmail(encoded);
+  assert.equal(decoded, email);
+});


### PR DESCRIPTION
## Summary
- export `encodeEmail` and add `decodeEmail` utility
- provide an example run when executed directly
- add a unit test for the email encoding/decoding cycle
- add `test` script to `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842843058ec83289b65b2a2826288f4