### PR TITLE
Add GitHub activity feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A modern, responsive portfolio website built with Svelte and Tailwind CSS.
 - Fast performance and accessibility features
 - Dark mode support
 - SEO optimized
+- GitHub activity feed
 
 ## Tech Stack
 
@@ -56,6 +57,7 @@ portfolio/
 │   ├── data/            # Project and skills data
 │   ├── lib/             # Utility functions
 │   ├── routes/          # Page routes
+│   │   └── api/github   # GitHub activity endpoint
 │   ├── app.css          # Global styles
 │   ├── app.html         # HTML template
 │   └── main.js          # Entry point

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -19,5 +19,6 @@
 	"page_title": "Kent Vuong | Full-Stack Software Developer",
 	"footer_name": "Kent Vuong",
 	"view_project": "View Project",
-	"resume_button": "Résumé"
+    "resume_button": "Résumé",
+    "github_heading": "Recent GitHub Activity"
 }

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -19,5 +19,6 @@
 	"page_title": "尊健翔 | フルスタックソフトウェア開発者",
 	"footer_name": "尊健翔",
 	"view_project": "プロジェクトを見る",
-	"resume_button": "履歴書"
+    "resume_button": "履歴書",
+    "github_heading": "最新のGitHubアクティビティ"
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { t } from '$lib/i18n/i18n'; // i18n import
 
-	const projects = [
+        const projects = [
 		{
 			title: 'Blob Site',
 			description:
@@ -45,15 +45,17 @@
 		}
 	];
 
-	function handleEmailClick() {
-		console.log('Email icon clicked');
-	}
-	function handleContactClick() {
-		console.log('Contact Me button clicked');
-	}
+        let githubRepos: { name: string; html_url: string; description: string }[] = [];
 
-	onMount(() => {
-		document.body.classList.add('loaded');
+        function handleEmailClick() {
+                console.log('Email icon clicked');
+        }
+        function handleContactClick() {
+                console.log('Contact Me button clicked');
+        }
+
+        onMount(async () => {
+                document.body.classList.add('loaded');
 
 		if (!document.querySelector('[src^="/emailProtection.js"]')) {
 			const script = document.createElement('script');
@@ -69,7 +71,16 @@
 			document.body.appendChild(script);
 		}
 
-		return () => {
+                try {
+                        const res = await fetch('/api/github');
+                        if (res.ok) {
+                                githubRepos = await res.json();
+                        }
+                } catch (e) {
+                        console.error('Failed to load GitHub data', e);
+                }
+
+                return () => {
 			const script = document.querySelector(`[src^="/emailProtection.js"]`);
 			if (script?.parentNode) {
 				script.parentNode.removeChild(script);
@@ -226,10 +237,31 @@
 				</div>
 			{/each}
 		</div>
-	</section>
+        </section>
 
-	<section id="contact" class="section container mx-auto px-12 py-12">
-		<h2>{$t('contact_heading')}</h2>
+        <section id="github" class="section container mx-auto px-12 py-12">
+                <h2 class="mb-8">{$t('github_heading')}</h2>
+                <ul>
+                        {#each githubRepos as repo}
+                                <li class="mb-4">
+                                        <a
+                                                href={repo.html_url}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                class="text-amber-600 hover:underline"
+                                        >
+                                                {repo.name}
+                                        </a>
+                                        {#if repo.description}
+                                                <p class="text-sm text-gray-700">{repo.description}</p>
+                                        {/if}
+                                </li>
+                        {/each}
+                </ul>
+        </section>
+
+        <section id="contact" class="section container mx-auto px-12 py-12">
+                <h2>{$t('contact_heading')}</h2>
 		<p>{$t('contact_text')}</p>
 		<a
 			href="mailto:contact@ktvuong.com"

--- a/src/routes/api/github/+server.ts
+++ b/src/routes/api/github/+server.ts
@@ -1,0 +1,25 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+const USERNAME = 'Mooshieblob1';
+
+export const GET: RequestHandler = async () => {
+    try {
+        const response = await fetch(
+            `https://api.github.com/users/${USERNAME}/repos?sort=updated&per_page=5`
+        );
+        if (!response.ok) {
+            return new Response('Failed to fetch GitHub data', { status: 500 });
+        }
+        const data = await response.json();
+        const repos = data.map((repo: any) => ({
+            name: repo.name,
+            html_url: repo.html_url,
+            description: repo.description
+        }));
+        return new Response(JSON.stringify(repos), {
+            headers: { 'content-type': 'application/json' }
+        });
+    } catch (err) {
+        return new Response('Error fetching GitHub data', { status: 500 });
+    }
+};


### PR DESCRIPTION
## Summary
- fetch recent GitHub repos via new API endpoint
- display recent GitHub activity on the home page
- localize heading for the new section
- document GitHub feed in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842883df708832886e269255dfd2ab5